### PR TITLE
Changes for tx_sample_scale and fast_attack mode AGC

### DIFF
--- a/debug_printf.c
+++ b/debug_printf.c
@@ -60,6 +60,11 @@ static bool should_print(debug_level level, debug_topics topic) {
     }
 }
 
+
+bool debug_printf_will_print(debug_level level, debug_topics topic) {
+        return should_print(level, topic);
+}
+
 void debug_printf(debug_level level, debug_topics topic, const char *format, ...) {
     char extended_format[1000];
 

--- a/debug_printf.c
+++ b/debug_printf.c
@@ -53,6 +53,9 @@ static bool should_print(debug_level level, debug_topics topic) {
         
         case DEBUG_FREQS:
                 return level <= LEVEL_INFO;
+
+        case DEBUG_DUMP:
+                return level <= LEVEL_INFO;
         
         default:
                 printf("Unhandled topic %d in debug_printf.\n", topic);

--- a/debug_printf.h
+++ b/debug_printf.h
@@ -26,8 +26,10 @@ typedef enum {
     DEBUG_RX,
     DEBUG_REGS,
     DEBUG_FREQS,
+    DEBUG_DUMP,
 } debug_topics;
 
 
+extern bool debug_printf_will_print(debug_level level, debug_topics topic);
 extern void debug_printf(debug_level level, debug_topics topic, const char *format, ...);
 extern void debug_printf_summary(void);

--- a/debug_printf.h
+++ b/debug_printf.h
@@ -1,5 +1,7 @@
 
 
+#include <stdbool.h>
+
 
 typedef enum {
     LEVEL_MUTE,

--- a/dialogus.c
+++ b/dialogus.c
@@ -161,7 +161,7 @@ int enable_msk_transmission(void) {
 	WRITE_MSK(MSK_Init, 0x00000000);  // Deassert txinit    
 	usleep(100);  // might not be needed?
 
-	WRITE_MSK(MSK_Control, 0x00000401);	// PTT on, loopback off, shift DAC bits left by 4
+	WRITE_MSK(MSK_Control, 0x00000001 | TX_DAC_BITSHIFT);	// PTT on, loopback off, shift DAC bits left
 
 	// Small delay to let hardware settle
 	usleep(1000);
@@ -176,7 +176,7 @@ int enable_msk_transmission(void) {
 // Disable PTT and stop MSK transmission
 int disable_msk_transmission(void) {
 	debug_printf(LEVEL_INFO, DEBUG_SESSION, "timeline @ %lld: Disabling MSK transmission (PTT OFF)\n", get_timestamp_us() - session_T0);
-	WRITE_MSK(MSK_Control, 0x00000400);	// PTT off
+	WRITE_MSK(MSK_Control, 0x00000000 | TX_DAC_BITSHIFT);	// PTT off
 
 	uint32_t status = READ_MSK(MSK_Status);
 	debug_printf(LEVEL_INFO, DEBUG_MSK, "MSK_Status after PTT disable: 0x%08x\n", status);

--- a/iio_ops.c
+++ b/iio_ops.c
@@ -135,6 +135,14 @@ bool cfg_ad9361_streaming_ch(struct stream_cfg *cfg, enum iodev type, int chid)
 	wr_ch_lli(chn, "rf_bandwidth",       cfg->bw_hz);
 	wr_ch_lli(chn, "sampling_frequency", cfg->fs_hz);
 
+	//use fast_attack AGC
+	// slow_attack is too slow and we miss the first frame sync word
+	// when a strong signal appears out of the silence
+	if (type == RX) {
+		wr_ch_str(chn, "gain_control_mode", "fast_attack");
+	}
+
+
 	// Configure LO channel
 	debug_printf(LEVEL_INFO, DEBUG_IIO, "* Acquiring AD9361 %s lo channel\n", type == TX ? "TX" : "RX");
 	if (!get_lo_chan(type, &chn)) { return false; }

--- a/iio_ops.c
+++ b/iio_ops.c
@@ -140,6 +140,7 @@ bool cfg_ad9361_streaming_ch(struct stream_cfg *cfg, enum iodev type, int chid)
 	// when a strong signal appears out of the silence
 	if (type == RX) {
 		wr_ch_str(chn, "gain_control_mode", "fast_attack");
+		debug_printf(LEVEL_INFO, DEBUG_IIO, "* Using fast_attack AGC mode\n");
 	}
 
 

--- a/iio_ops.c
+++ b/iio_ops.c
@@ -164,7 +164,7 @@ void iio_setup(void)
 	rxcfg.fs_hz = MHZ(61.44);	// 2.5 MS/s rx sample rate
 	rxcfg.lo_hz = LO_FREQ_FOR_CHANNEL_CENTER(RX_CHANNEL_CENTER);
 	rxcfg.rf_port = "A_BALANCED";	// port A (select for rf freq.)
-	debug_printf(LEVEL_INFO, DEBUG_FREQS, "Receive channel center: %lld Hz", RX_CHANNEL_CENTER);
+	debug_printf(LEVEL_INFO, DEBUG_FREQS, "Receive channel center: %lld Hz\n", RX_CHANNEL_CENTER);
 
 	// OPV hardware TX stream config
 	struct stream_cfg txcfg;
@@ -172,7 +172,7 @@ void iio_setup(void)
 	txcfg.fs_hz = MHZ(61.44);	// 2.5 MS/s tx sample rate
 	txcfg.lo_hz = LO_FREQ_FOR_CHANNEL_CENTER(TX_CHANNEL_CENTER);
 	txcfg.rf_port = "A";	// port A (select for rf freq.)
-	debug_printf(LEVEL_INFO, DEBUG_FREQS, "Transmit channel center: %lld Hz", TX_CHANNEL_CENTER);
+	debug_printf(LEVEL_INFO, DEBUG_FREQS, "Transmit channel center: %lld Hz\n", TX_CHANNEL_CENTER);
 
 	debug_printf(LEVEL_INFO, DEBUG_IIO, "* Acquiring IIO context\n");
 	IIO_ENSURE((ctx = iio_create_default_context()) && "No context");

--- a/msk_setup.c
+++ b/msk_setup.c
@@ -130,9 +130,9 @@ void msk_setup(void)
 	WRITE_MSK(LPF_Config_0, 0x00000000);	//accumulators in normal operation
 	printf("Wrote all 0 LPF_Config_0: (0x%08x@%04x)\n", READ_MSK(LPF_Config_0), OFFSET_MSK(LPF_Config_0));
 
-	printf("Write some default values for PI gain and bit shift.\n");
-	WRITE_MSK(LPF_Config_1, 0x1d7fffff);	// Integral gain: 0x1d shift (29), value 0x7f_ffff (half scale)
-	WRITE_MSK(LPF_Config_2, 0x147fffff);	// Proportional gain: 0x14 shift (20), value 0x7f_ffff (half scale)
+	printf("Write some arbitrary test values for PI gain and bit shift.\n");
+	WRITE_MSK(LPF_Config_1, 0x005a5a5a);
+	WRITE_MSK(LPF_Config_2, 0x00a5a5a5);
 	printf("LPF_Config_0: (0x%08x@%04x)\n", READ_MSK(LPF_Config_0), OFFSET_MSK(LPF_Config_0));
 	printf("LPF_Config_1: (0x%08x@%04x)\n", READ_MSK(LPF_Config_1), OFFSET_MSK(LPF_Config_1));
 	printf("LPF_Config_2: (0x%08x@%04x)\n", READ_MSK(LPF_Config_2), OFFSET_MSK(LPF_Config_2));
@@ -167,8 +167,8 @@ void msk_setup(void)
 
 	int32_t proportional_gain =           0x007FFFFF;	// 0x00000243; //0x0012984F for 32 bits 0x00001298 for 24 bits 243 for OE 
 	int32_t integral_gain =          	  0x007FFFFF;	// 0x000005A7; //0x0000C067 for 32 bits and 80 for 0E
-	int32_t proportional_gain_bit_shift = 18;	//0x0000000E; //0x18 is 24 and 0x20 is 32 and 0E is 14
-	int32_t integral_gain_bit_shift =     27;	//0x00000019; //0x18 is 24 and 0x20 is 32 and 0E is 14
+	int32_t proportional_gain_bit_shift = 20;	// Proportional gain: 0x14 shift (20)
+	int32_t integral_gain_bit_shift =     29;	// Integral gain: 0x1d shift (29)
 
 	int32_t proportional_config = (proportional_gain_bit_shift << 24) | (proportional_gain & 0x00FFFFFF);
 	int32_t integral_config = (integral_gain_bit_shift << 24) | (integral_gain & 0x00FFFFFF);

--- a/msk_setup.c
+++ b/msk_setup.c
@@ -53,8 +53,8 @@ void msk_setup(void)
 
 	printf("-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-\n");
 	printf("OVP_FRAME_MODE: Configuring for frame-driven transmission\n");
-	printf("PTT off, loopback off, waiting for OVP frames, shift DAC bits left by 4\n");
-	WRITE_MSK(MSK_Control, 0x00000400);
+	printf("PTT off, loopback off, waiting for OVP frames, shift DAC bits leftn");
+	WRITE_MSK(MSK_Control, 0x00000000 | TX_DAC_BITSHIFT);
 	printf("Reading back MSK_CONTROL status register. We see: (0x%08x@%04x)\n", READ_MSK(MSK_Control), OFFSET_MSK(MSK_Control));
 	printf("-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-\n");
 

--- a/msk_setup.c
+++ b/msk_setup.c
@@ -131,11 +131,15 @@ void msk_setup(void)
 	printf("Wrote all 0 LPF_Config_0: (0x%08x@%04x)\n", READ_MSK(LPF_Config_0), OFFSET_MSK(LPF_Config_0));
 
 	printf("Write some default values for PI gain and bit shift.\n");
-	WRITE_MSK(LPF_Config_1, 0x005a5a5a);
-	WRITE_MSK(LPF_Config_2, 0x00a5a5a5);
+	WRITE_MSK(LPF_Config_1, 0x1d7fffff);	// Integral gain: 0x1d shift (29), value 0x7f_ffff (half scale)
+	WRITE_MSK(LPF_Config_2, 0x147fffff);	// Proportional gain: 0x14 shift (20), value 0x7f_ffff (half scale)
 	printf("LPF_Config_0: (0x%08x@%04x)\n", READ_MSK(LPF_Config_0), OFFSET_MSK(LPF_Config_0));
 	printf("LPF_Config_1: (0x%08x@%04x)\n", READ_MSK(LPF_Config_1), OFFSET_MSK(LPF_Config_1));
 	printf("LPF_Config_2: (0x%08x@%04x)\n", READ_MSK(LPF_Config_2), OFFSET_MSK(LPF_Config_2));
+
+	printf("Write a default value for symbol lock count and threshold.\n");
+	WRITE_MSK(symbol_lock_control, 0x002e2010);	// symbol lock count = 0x10 (16), symbol lock threshold = 0x0bb8 (3000)
+	printf("symbol_lock_control: (0x%08x@%04x)\n", READ_MSK(symbol_lock_control), OFFSET_MSK(symbol_lock_control));
 
 	printf("-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-\n");
 	printf("Set TX_DATA_WIDTH to 8.\n");

--- a/msk_setup.c
+++ b/msk_setup.c
@@ -138,7 +138,7 @@ void msk_setup(void)
 	printf("LPF_Config_2: (0x%08x@%04x)\n", READ_MSK(LPF_Config_2), OFFSET_MSK(LPF_Config_2));
 
 	printf("Write a default value for symbol lock count and threshold.\n");
-	WRITE_MSK(symbol_lock_control, 0x002e2010);	// symbol lock count = 0x10 (16), symbol lock threshold = 0x0b88 (2952)
+	WRITE_MSK(symbol_lock_control, 0x00026410);	// symbol lock count = 0x010 (16), symbol lock threshold = 0x0099 (153, encoding 153*2^16)
 	printf("symbol_lock_control: (0x%08x@%04x)\n", READ_MSK(symbol_lock_control), OFFSET_MSK(symbol_lock_control));
 
 	printf("-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-\n");

--- a/msk_setup.c
+++ b/msk_setup.c
@@ -166,10 +166,10 @@ void msk_setup(void)
 */
 
 	int32_t proportional_gain =           0x007FFFFF;	// 0x00000243; //0x0012984F for 32 bits 0x00001298 for 24 bits 243 for OE 
-//	int32_t integral_gain =          	  0x007FFFFF;	// 0x000005A7; //0x0000C067 for 32 bits and 80 for 0E
-	int32_t integral_gain =          	  0x00000000;	// zero integral for searching proportional gain
-//	int32_t proportional_gain_bit_shift = 20;	// Proportional gain: 0x14 shift (20)
-	int32_t proportional_gain_bit_shift = 16;	// Proportional gain: start at 0x10 shift (16)
+	int32_t integral_gain =          	  0x007FFFFF;	// 0x000005A7; //0x0000C067 for 32 bits and 80 for 0E
+//used for first scan	int32_t integral_gain =          	  0x00000000;	// zero integral for searching proportional gain
+	int32_t proportional_gain_bit_shift = 20;	// Proportional gain: 0x14 shift (20)
+//used for first scan	int32_t proportional_gain_bit_shift = 24;	// Proportional gain: start at 0x10 shift (16)
 	int32_t integral_gain_bit_shift =     29;	// Integral gain: 0x1d shift (29)
 
 	int32_t proportional_config = (proportional_gain_bit_shift << 24) | (proportional_gain & 0x00FFFFFF);

--- a/msk_setup.c
+++ b/msk_setup.c
@@ -138,7 +138,7 @@ void msk_setup(void)
 	printf("LPF_Config_2: (0x%08x@%04x)\n", READ_MSK(LPF_Config_2), OFFSET_MSK(LPF_Config_2));
 
 	printf("Write a default value for symbol lock count and threshold.\n");
-	WRITE_MSK(symbol_lock_control, 0x002e2010);	// symbol lock count = 0x10 (16), symbol lock threshold = 0x0bb8 (3000)
+	WRITE_MSK(symbol_lock_control, 0x002e2010);	// symbol lock count = 0x10 (16), symbol lock threshold = 0x0b88 (2952)
 	printf("symbol_lock_control: (0x%08x@%04x)\n", READ_MSK(symbol_lock_control), OFFSET_MSK(symbol_lock_control));
 
 	printf("-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-\n");
@@ -166,8 +166,10 @@ void msk_setup(void)
 */
 
 	int32_t proportional_gain =           0x007FFFFF;	// 0x00000243; //0x0012984F for 32 bits 0x00001298 for 24 bits 243 for OE 
-	int32_t integral_gain =          	  0x007FFFFF;	// 0x000005A7; //0x0000C067 for 32 bits and 80 for 0E
-	int32_t proportional_gain_bit_shift = 20;	// Proportional gain: 0x14 shift (20)
+//	int32_t integral_gain =          	  0x007FFFFF;	// 0x000005A7; //0x0000C067 for 32 bits and 80 for 0E
+	int32_t integral_gain =          	  0x00000000;	// zero integral for searching proportional gain
+//	int32_t proportional_gain_bit_shift = 20;	// Proportional gain: 0x14 shift (20)
+	int32_t proportional_gain_bit_shift = 16;	// Proportional gain: start at 0x10 shift (16)
 	int32_t integral_gain_bit_shift =     29;	// Integral gain: 0x1d shift (29)
 
 	int32_t proportional_config = (proportional_gain_bit_shift << 24) | (proportional_gain & 0x00FFFFFF);

--- a/registers.h
+++ b/registers.h
@@ -59,5 +59,7 @@ uint32_t capture_and_read_msk(size_t offset);
 #define TX_SYNC_CTRL_AUTO   0x00000001  // enabled when transmitter turns on
 #define TX_SYNC_CTRL_FORCE  0x00000002  // enabled now
 
+// Value for bit shift between 12-bit RX values (right aligned) and TX values (left aligned in 16 bits)
+#define TX_DAC_BITSHIFT 0x00000400  // tx shift of 4 bits left
 
 #endif // REGISTERS_H


### PR DESCRIPTION
This brings Dialogus main up to the current lab version.

Includes changes to support the missing dB addressed in pluto_msk tx_sample_scale branch, and also switches the AGC mode to fast_attack.

Does not include tuning the AGC parameters for fast_attack, because we haven't done that yet!